### PR TITLE
use stderr instead of stdout

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,7 @@ interface LoaderInstance {
     tsConfigPath?: string;
 }
 
-console.log(`[light-ts-loader] Using typescript@${ts.version}`);
+console.warn(`[light-ts-loader] Using typescript@${ts.version}`);
 
 function loader(source: string) {
     const _loaderInstance: LoaderInstance = this;


### PR DESCRIPTION
Sometimes, webpack's stdout is rediredted to a JSON files. e.g.:

```sh
webpack --json > stats.json
# ...and upload stats.json to http://webpack.github.io/analyse/ for analysis
```

Including `[light-ts-loader] Using typescript@2.2.1` at the first line, the stats.json gets broken 😭  